### PR TITLE
feat/#45: 검색 필터용 시/도, 시/군/구 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/ganzi/backend/animal/api/AnimalController.java
+++ b/src/main/java/com/ganzi/backend/animal/api/AnimalController.java
@@ -10,6 +10,7 @@ import com.ganzi.backend.global.security.userdetails.CustomUserDetails;
 import com.ganzi.backend.user.api.dto.RecordInterestRequest;
 import com.ganzi.backend.user.application.UserInterestService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -17,7 +18,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -56,5 +64,19 @@ public class AnimalController implements AnimalControllerDoc {
         Long userId = userDetails.getUser().getId();
         userInterestService.recordInterest(userId, request.desertionNo(), request.dwellTimeSeconds(), request.liked());
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Override
+    @GetMapping("/provinces")
+    public ResponseEntity<ApiResponse<List<String>>> findProvinces() {
+        List<String> response = animalService.findProvinces();
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Override
+    @GetMapping("/cities")
+    public ResponseEntity<ApiResponse<List<String>>> findCities(@RequestParam(required = false) String province) {
+        List<String> response = animalService.findCities(province);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/ganzi/backend/animal/api/doc/AnimalControllerDoc.java
+++ b/src/main/java/com/ganzi/backend/animal/api/doc/AnimalControllerDoc.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "유기동물", description = "유기동물 조회 API")
 public interface AnimalControllerDoc {
@@ -122,5 +124,42 @@ public interface AnimalControllerDoc {
     ResponseEntity<ApiResponse<Void>> recordUserInterest(
             @Valid @RequestBody RecordInterestRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "시/도 목록 조회",
+            description = """
+                      검색 필터에 사용할 수 있는 시/도 목록을 조회합니다.
+
+                      ### 응답 데이터
+                      - DB에 저장된 고유한 시/도 목록
+                      - 가나다순으로 정렬
+                      - null 값은 제외
+                      """
+    )
+    ResponseEntity<ApiResponse<List<String>>> findProvinces();
+
+    @Operation(
+            summary = "시/군/구 목록 조회",
+            description = """
+                      검색 필터에 사용할 수 있는 시/군/구 목록을 조회합니다.
+
+                      ### 쿼리 파라미터
+                      - `province`: 특정 시/도의 시/군/구만 조회 (선택사항)
+                      - 입력하지 않으면 전체 시/군/구 목록 반환
+
+                      ### 응답 데이터
+                      - DB에 저장된 고유한 시/군/구 목록
+                      - 가나다순으로 정렬
+                      - null 값은 제외
+
+                      ### 사용 예시
+                      1. 전체 시/군/구 조회: `/api/animals/cities`
+                      2. 특정 시/도의 시/군/구 조회: `/api/animals/cities?province=서울특별시`
+                      """
+    )
+    ResponseEntity<ApiResponse<List<String>>> findCities(
+            @Parameter(description = "시/도 (선택사항, 입력 시 해당 시/도의 시/군/구만 조회)")
+            @RequestParam(required = false) String province
     );
 }

--- a/src/main/java/com/ganzi/backend/animal/application/AnimalService.java
+++ b/src/main/java/com/ganzi/backend/animal/application/AnimalService.java
@@ -7,6 +7,7 @@ import com.ganzi.backend.animal.domain.Animal;
 import com.ganzi.backend.animal.domain.repository.AnimalRepository;
 import com.ganzi.backend.global.code.status.ErrorStatus;
 import com.ganzi.backend.global.exception.GeneralException;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,5 +31,13 @@ public class AnimalService {
         Animal animal = animalRepository.findById(desertionNo)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ANIMAL_NOT_FOUND));
         return AnimalDetailResponse.from(animal);
+    }
+
+    public List<String> findProvinces() {
+        return animalRepository.findDistinctProvinces();
+    }
+
+    public List<String> findCities(String province) {
+        return animalRepository.findDistinctCitesByProvince(province);
     }
 }

--- a/src/main/java/com/ganzi/backend/animal/domain/repository/AnimalRepository.java
+++ b/src/main/java/com/ganzi/backend/animal/domain/repository/AnimalRepository.java
@@ -1,10 +1,20 @@
 package com.ganzi.backend.animal.domain.repository;
 
 import com.ganzi.backend.animal.domain.Animal;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnimalRepository extends JpaRepository<Animal, String>, AnimalRepositoryCustom {
     Optional<Animal> findByDesertionNo(String desertionNo);
+
+    @Query("SELECT DISTINCT a.province FROM Animal a " +
+            "WHERE a.province IS NOT NULL ORDER BY a.province")
+    List<String> findDistinctProvinces();
+
+    @Query("SELECT DISTINCT a.city FROM Animal a " +
+            "WHERE (:province IS NULL OR a.province = :province) AND a.city IS NOT NULL ORDER BY a.city")
+    List<String> findDistinctCitesByProvince(@Param("province") String province);
 }


### PR DESCRIPTION
## #️⃣ Issue Number
feat/#45
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 프론트엔드에서 유기동물 검색 필터를 구현할 때 하드코딩이 아닌 DB에서 가져올 수 있게 제공
- 공공 API를 통해 가져오는 시/도, 시/군/구 값을 중복 없이 저장 후 조회
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
